### PR TITLE
Add dataset download script and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # hnscc-analysis
+
+This repository provides helper scripts for obtaining the HNSCC dataset used in the ML Copilot Agent case study.
+
+## Downloading the dataset
+
+Run `scripts/download_dataset.sh` to clone the dataset from Hugging Face:
+
+```bash
+./scripts/download_dataset.sh
+```
+
+The paths to the processed data files are defined in `scripts/data_paths.py`.
+

--- a/scripts/data_paths.py
+++ b/scripts/data_paths.py
@@ -1,0 +1,7 @@
+"""Configuration file for dataset paths."""
+
+TCGA_EXPRESSION_FILE = "/content/Case-Study-HNSCC-ML-Copilot-Agent/processed_data/tcga.survival.fcptac.csv"
+TCGA_SURVIVAL_FILE = "/content/Case-Study-HNSCC-ML-Copilot-Agent/processed_data/survival_tcga.csv"
+CPTAC_EXPRESSION_FILE = "/content/Case-Study-HNSCC-ML-Copilot-Agent/processed_data/cptac.survival.fcptac.csv"
+CPTAC_SURVIVAL_FILE = "/content/Case-Study-HNSCC-ML-Copilot-Agent/processed_data/survival_cptac.csv"
+

--- a/scripts/download_dataset.sh
+++ b/scripts/download_dataset.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Script to download the HNSCC dataset from Hugging Face
+# Usage: ./download_dataset.sh [TARGET_DIR]
+# The dataset will be cloned into TARGET_DIR or into
+# Case-Study-HNSCC-ML-Copilot-Agent if TARGET_DIR is not specified.
+
+set -e
+
+REPO_URL="https://huggingface.co/datasets/VatsalPatel18/Case-Study-HNSCC-ML-Copilot-Agent"
+TARGET_DIR="${1:-Case-Study-HNSCC-ML-Copilot-Agent}"
+
+if [ -d "$TARGET_DIR" ]; then
+    echo "Target directory $TARGET_DIR already exists. Skipping clone."
+else
+    git clone "$REPO_URL" "$TARGET_DIR"
+fi
+


### PR DESCRIPTION
## Summary
- add `download_dataset.sh` shell script to clone dataset from Hugging Face
- add `data_paths.py` with predefined file paths for the dataset
- clean up and expand README with download instructions

## Testing
- `./scripts/download_dataset.sh` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6850210e8848832ba70c660bac793a6b