### PR TITLE
Fix import in validation script

### DIFF
--- a/analysis_scripts/step7_validation_summary.py
+++ b/analysis_scripts/step7_validation_summary.py
@@ -2,6 +2,7 @@
 """Step 7: Validate models and create summary tables."""
 
 import os
+import pickle
 import numpy as np
 import pandas as pd
 from lifelines.statistics import logrank_test


### PR DESCRIPTION
## Summary
- import pickle for model loading in `step7_validation_summary.py`

## Testing
- `python -m py_compile analysis_scripts/step7_validation_summary.py`
- `python run_pipeline.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6851062f3e34832bb8f4f135ed5f5b45