### PR TITLE
Remove plt.show calls and save figures with tight layout

### DIFF
--- a/analysis_scripts/step11_extra_visualizations.py
+++ b/analysis_scripts/step11_extra_visualizations.py
@@ -84,7 +84,7 @@ def plot_mean_roc_feature_grid(out_file, feature_sizes=None, models=None):
     fig.suptitle("Mean ROC Curves \u00b1 Std Dev Across Models for Various Feature Sizes",
                  fontsize=16, y=0.94)
     plt.tight_layout(rect=[0, 0, 1, 0.92])
-    plt.savefig(out_file, dpi=300)
+    plt.savefig(out_file, bbox_inches="tight", dpi=300)
     plt.close(fig)
     print(f"Saved ROC grid plot to: {out_file}")
     with open(LOG_FILE, "a") as f:
@@ -109,7 +109,7 @@ def plot_auc_boxplot(out_file):
     plt.ylabel("Test-set AUC")
     plt.legend(title="Model", bbox_to_anchor=(1.05, 1), loc="upper left")
     plt.tight_layout()
-    plt.savefig(out_file, dpi=300)
+    plt.savefig(out_file, bbox_inches="tight", dpi=300)
     plt.close()
     print(f"Saved AUC boxplot to: {out_file}")
     with open(LOG_FILE, "a") as f:
@@ -164,8 +164,8 @@ def plot_upset(feature_sets, out_file):
     upset = UpSet(memberships, subset_size='count', show_counts=True, sort_by='degree')
     upset.plot()
     plt.suptitle("Feature Overlap Across Best Model Runs", fontsize=14)
-    plt.savefig(out_file, dpi=300)
     plt.tight_layout()
+    plt.savefig(out_file, bbox_inches="tight", dpi=300)
     plt.close()
     print(f"Saved UpSet plot to: {out_file}")
     with open(LOG_FILE, "a") as f:
@@ -188,7 +188,7 @@ def plot_feature_heatmap(feature_sets, out_file):
     plt.xlabel("Feature Size")
     plt.ylabel("Gene")
     plt.tight_layout()
-    plt.savefig(out_file, dpi=300)
+    plt.savefig(out_file, bbox_inches="tight", dpi=300)
     plt.close()
     print(f"Saved heatmap to: {out_file}")
     with open(LOG_FILE, "a") as f:
@@ -232,7 +232,7 @@ def plot_feature_frequencies(out_dir):
         ax.set_ylabel("Feature")
         plt.tight_layout()
         out_file = os.path.join(out_dir, f"feature_frequency_f{fsize}.png")
-        plt.savefig(out_file, dpi=300)
+        plt.savefig(out_file, bbox_inches="tight", dpi=300)
         plt.close()
         print(f"Saved frequency plot to: {out_file}")
         with open(LOG_FILE, "a") as f:

--- a/analysis_scripts/step2_helper_functions.py
+++ b/analysis_scripts/step2_helper_functions.py
@@ -89,10 +89,7 @@ def run_multi_group_survival(df_survival_with_clusters, cluster_col="Cluster",
         except Exception as e:
             print(f"Error saving plot {plot_filename}: {e}")
 
-    if show_plot:
-        plt.show()
-    else:
-        plt.close(fig)
+    plt.close(fig)
 
     return min_p, cluster_distribution, signif_text, medians
 
@@ -199,6 +196,6 @@ def plot_roc_curves_all_models(roc_storage, models_to_plot, feature_sizes,
             f.write(f"  Saved ROC curve plot: {output_file}\n")
     except Exception as e:
         print(f"Error saving ROC plot {output_file}: {e}")
-    plt.show()
+    plt.close()
 
 print("Helper functions defined.")

--- a/analysis_scripts/step4_prepare_binary_classification.py
+++ b/analysis_scripts/step4_prepare_binary_classification.py
@@ -94,4 +94,4 @@ plt.savefig(vis_path, bbox_inches='tight', dpi=150)
 print(f"Saved binary target visualization to: {vis_path}")
 with open(LOG_FILE, 'a') as f:
     f.write(f"  Saved binary target viz: {vis_path}\n")
-plt.show()
+plt.close()

--- a/analysis_scripts/step6_aggregate_visualize.py
+++ b/analysis_scripts/step6_aggregate_visualize.py
@@ -55,7 +55,7 @@ plt.tight_layout(rect=[0, 0.03, 1, 0.98])
 boxplot_file = os.path.join(DIRS["plots_classification"], "auc_boxplots_by_model.png")
 plt.savefig(boxplot_file, bbox_inches="tight", dpi=150)
 print(f"Saved AUC boxplots to: {boxplot_file}")
-plt.show()
+plt.close()
 
 print("Generating Mean AUC line plots...")
 plt.figure(figsize=(10, 7))
@@ -97,7 +97,7 @@ plt.xticks(FEATURE_SIZES, labels=[str(fs) for fs in FEATURE_SIZES], rotation=45,
 lineplot_file = os.path.join(DIRS["plots_classification"], "auc_mean_std_lines_by_model.png")
 plt.savefig(lineplot_file, bbox_inches="tight", dpi=150)
 print(f"Saved Mean AUC line plot to: {lineplot_file}")
-plt.show()
+plt.close()
 
 print("Generating ROC plots...")
 roc_plot_file = os.path.join(DIRS["plots_classification"], "roc_curves_by_model.png")


### PR DESCRIPTION
## Summary
- remove interactive `plt.show()` calls in analysis scripts
- ensure all saved figures use `bbox_inches='tight'`

## Testing
- `python -m py_compile analysis_scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68515f5991bc832ba4a3063a45146445