### PR TITLE
Add detailed classification metrics and dataset plot

### DIFF
--- a/analysis_scripts/classification3_5_metrics_plots.py
+++ b/analysis_scripts/classification3_5_metrics_plots.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Step classification3.5: Visualization of train/test metrics across datasets."""
+
+import os
+import pandas as pd
+import matplotlib.pyplot as plt
+
+from step0_setup import DIRS, LOG_FILE
+
+metrics_file = os.path.join(DIRS["results"], "classification_metrics_detailed.csv")
+if not os.path.exists(metrics_file):
+    raise RuntimeError(
+        "Detailed metrics file not found. Run step5_classification_loop first."
+    )
+
+df = pd.read_csv(metrics_file)
+
+print("\n--- classification3.5: Plotting average metrics across datasets ---")
+
+metric_cols = ["Accuracy", "Precision", "Recall", "F1"]
+agg = df.groupby("Dataset")[metric_cols].mean().reindex([
+    "Train (TCGA)",
+    "Test (TCGA)",
+    "CPTAC",
+])
+
+fig, ax = plt.subplots(figsize=(8, 6))
+agg.plot(kind="bar", ax=ax)
+ax.set_title("Average Classification Metrics by Dataset")
+ax.set_ylabel("Score")
+ax.set_ylim(0, 1)
+ax.grid(True, linestyle="--", alpha=0.6)
+plt.xticks(rotation=45, ha="right")
+plt.tight_layout()
+
+out_file = os.path.join(DIRS["plots_classification"], "avg_metrics_by_dataset.png")
+plt.savefig(out_file, bbox_inches="tight", dpi=150)
+plt.close()
+print(f"Saved metric comparison plot to: {out_file}")
+
+with open(LOG_FILE, "a") as f:
+    f.write("\nclassification3.5 Visualization:\n")
+    f.write(f"  Saved metrics plot: {out_file}\n")
+
+print("Metric visualization complete.")

--- a/analysis_scripts/step5_classification_loop.py
+++ b/analysis_scripts/step5_classification_loop.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-"""Step 5: Binary classification loop over multiple runs."""
+"""Step 5: Binary classification loop over multiple runs.
+
+This step now records train/test metrics, optional CPTAC metrics (if labels are
+available), and saves per-sample prediction tables for all runs.
+"""
 
 import os
 import pickle
@@ -9,30 +13,55 @@ from sklearn.model_selection import train_test_split
 from sklearn.feature_selection import SelectKBest, f_classif
 from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score, roc_auc_score, roc_curve
 
-from step0_setup import FEATURE_SIZES, RUNS, CLASSIFIERS, DIRS, LOG_FILE
-from step4_prepare_binary_classification import X_full_binary, y_full_binary, feature_names_all
+from step0_setup import (
+    FEATURE_SIZES,
+    RUNS,
+    CLASSIFIERS,
+    DIRS,
+    LOG_FILE,
+    CPTAC_EXPRESSION_FILE,
+)
+from step4_prepare_binary_classification import (
+    X_full_binary,
+    y_full_binary,
+    feature_names_all,
+    df_expr_binary,
+    df_binary_subset,
+)
 
 def main():
     print(
         f"\n--- 5. Starting Binary Classification Loop ({RUNS} Runs, Feature Sizes: {FEATURE_SIZES}) ---"
     )
     classification_results_list = []
+    detailed_metrics_list = []
+    predictions_list = []
     roc_data_storage = {}
+
+    try:
+        df_expr_cptac = pd.read_csv(CPTAC_EXPRESSION_FILE, index_col="PatientID")
+    except Exception as e:
+        print(f"Warning: Could not load CPTAC expression data: {e}")
+        df_expr_cptac = pd.DataFrame()
 
     for fsize in FEATURE_SIZES:
         print(f"\n=== Feature Selection Size: {fsize} ===")
         for model_name in CLASSIFIERS.keys():
             roc_data_storage[(model_name, fsize)] = []
 
+        patient_ids = df_expr_binary.index.values
         for run in range(1, RUNS + 1):
             print(f"  --- Run {run}/{RUNS} ---")
-            X_train, X_test, y_train, y_test = train_test_split(
-                X_full_binary,
-                y_full_binary,
+            idx_train, idx_test = train_test_split(
+                np.arange(len(y_full_binary)),
                 test_size=0.3,
                 random_state=42 + run,
                 stratify=y_full_binary,
             )
+            X_train = X_full_binary[idx_train]
+            X_test = X_full_binary[idx_test]
+            y_train = y_full_binary[idx_train]
+            y_test = y_full_binary[idx_test]
             k_fs = min(fsize, X_train.shape[1])
             if k_fs < 1:
                 print(f"Warning: Feature size {fsize} resulted in k={k_fs}. Skipping.")
@@ -59,6 +88,17 @@ def main():
                 clf = clf_prototype
                 try:
                     clf.fit(X_train_fs, y_train)
+
+                    # Predictions on training data
+                    y_train_pred = clf.predict(X_train_fs)
+                    y_train_proba = clf.predict_proba(X_train_fs)[:, 1]
+                    acc_tr = accuracy_score(y_train, y_train_pred)
+                    prec_tr = precision_score(y_train, y_train_pred, zero_division=0)
+                    rec_tr = recall_score(y_train, y_train_pred, zero_division=0)
+                    f1_tr = f1_score(y_train, y_train_pred, zero_division=0)
+                    auc_tr = roc_auc_score(y_train, y_train_proba)
+
+                    # Predictions on test data
                     y_pred = clf.predict(X_test_fs)
                     y_proba = clf.predict_proba(X_test_fs)[:, 1]
                     acc = accuracy_score(y_test, y_pred)
@@ -67,6 +107,26 @@ def main():
                     f1 = f1_score(y_test, y_pred, zero_division=0)
                     auc = roc_auc_score(y_test, y_proba)
                     fpr, tpr, _ = roc_curve(y_test, y_proba)
+
+                    # Predictions on CPTAC if possible
+                    acc_cpt = prec_cpt = rec_cpt = f1_cpt = auc_cpt = np.nan
+                    cptac_ids = []
+                    cptac_proba = []
+                    if not df_expr_cptac.empty:
+                        try:
+                            X_cptac_fs = df_expr_cptac[selected_features].values
+                            cptac_proba = clf.predict_proba(X_cptac_fs)[:, 1]
+                            # If CPTAC has true labels use them, else keep NaN metrics
+                            if "Label" in df_expr_cptac.columns:
+                                y_cpt = df_expr_cptac["Label"].values
+                                y_cpt_pred = clf.predict(X_cptac_fs)
+                                acc_cpt = accuracy_score(y_cpt, y_cpt_pred)
+                                prec_cpt = precision_score(y_cpt, y_cpt_pred, zero_division=0)
+                                rec_cpt = recall_score(y_cpt, y_cpt_pred, zero_division=0)
+                                f1_cpt = f1_score(y_cpt, y_cpt_pred, zero_division=0)
+                                auc_cpt = roc_auc_score(y_cpt, cptac_proba)
+                        except Exception as e:
+                            print(f"        Warning: CPTAC prediction failed: {e}")
 
                     classification_results_list.append(
                         {
@@ -81,6 +141,106 @@ def main():
                             "NumSelectedFeatures": k_fs,
                         }
                     )
+                    # store detailed metrics for each dataset
+                    detailed_metrics_list.extend([
+                        {
+                            "FeatureSize": fsize,
+                            "Run": run,
+                            "Model": model_name,
+                            "Dataset": "Train (TCGA)",
+                            "Accuracy": acc_tr,
+                            "Precision": prec_tr,
+                            "Recall": rec_tr,
+                            "F1": f1_tr,
+                            "AUC": auc_tr,
+                            "NumSelectedFeatures": k_fs,
+                        },
+                        {
+                            "FeatureSize": fsize,
+                            "Run": run,
+                            "Model": model_name,
+                            "Dataset": "Test (TCGA)",
+                            "Accuracy": acc,
+                            "Precision": prec,
+                            "Recall": rec,
+                            "F1": f1,
+                            "AUC": auc,
+                            "NumSelectedFeatures": k_fs,
+                        },
+                        {
+                            "FeatureSize": fsize,
+                            "Run": run,
+                            "Model": model_name,
+                            "Dataset": "CPTAC",
+                            "Accuracy": acc_cpt,
+                            "Precision": prec_cpt,
+                            "Recall": rec_cpt,
+                            "F1": f1_cpt,
+                            "AUC": auc_cpt,
+                            "NumSelectedFeatures": k_fs,
+                        },
+                    ])
+
+                    # store prediction details
+                    for pid, tlabel, plab, pprob in zip(
+                        patient_ids[idx_train],
+                        y_train,
+                        y_train_pred,
+                        y_train_proba,
+                    ):
+                        predictions_list.append(
+                            {
+                                "FeatureSize": fsize,
+                                "Run": run,
+                                "Model": model_name,
+                                "Dataset": "Train (TCGA)",
+                                "PatientID": pid,
+                                "TrueLabel": tlabel,
+                                "PredictedLabel": plab,
+                                "PredictedProbability_Class1": pprob,
+                            }
+                        )
+
+                    for pid, tlabel, plab, pprob in zip(
+                        patient_ids[idx_test],
+                        y_test,
+                        y_pred,
+                        y_proba,
+                    ):
+                        predictions_list.append(
+                            {
+                                "FeatureSize": fsize,
+                                "Run": run,
+                                "Model": model_name,
+                                "Dataset": "Test (TCGA)",
+                                "PatientID": pid,
+                                "TrueLabel": tlabel,
+                                "PredictedLabel": plab,
+                                "PredictedProbability_Class1": pprob,
+                            }
+                        )
+
+                    if not df_expr_cptac.empty:
+                        cptac_ids = df_expr_cptac.index.tolist()
+                        for pid, pprob in zip(cptac_ids, cptac_proba):
+                            predictions_list.append(
+                                {
+                                    "FeatureSize": fsize,
+                                    "Run": run,
+                                    "Model": model_name,
+                                    "Dataset": "CPTAC",
+                                    "PatientID": pid,
+                                    "TrueLabel": df_expr_cptac["Label"].loc[pid]
+                                    if "Label" in df_expr_cptac.columns
+                                    else np.nan,
+                                    "PredictedLabel": np.nan
+                                    if "Label" not in df_expr_cptac.columns
+                                    else clf.predict(X_cptac_fs)[
+                                        list(df_expr_cptac.index).index(pid)
+                                    ],
+                                    "PredictedProbability_Class1": pprob,
+                                }
+                            )
                     roc_data_storage[(model_name, fsize)].append(
                         {"run": run, "fpr": fpr, "tpr": tpr, "auc": auc}
                     )
@@ -128,6 +288,16 @@ def main():
     results_df.to_csv(results_csv, index=False)
     print(f"\nSaved detailed classification metrics to: {results_csv}")
 
+    detailed_df = pd.DataFrame(detailed_metrics_list)
+    detailed_csv = os.path.join(DIRS["results"], "classification_metrics_detailed.csv")
+    detailed_df.to_csv(detailed_csv, index=False)
+    print(f"Saved extended metrics to: {detailed_csv}")
+
+    pred_df = pd.DataFrame(predictions_list)
+    pred_csv = os.path.join(DIRS["results_predictions"], "all_predictions_all_runs.csv")
+    pred_df.to_csv(pred_csv, index=False)
+    print(f"Saved all prediction outputs to: {pred_csv}")
+
     roc_data_file = os.path.join(DIRS["results"], "roc_data_all_runs.pkl")
     with open(roc_data_file, "wb") as f:
         pickle.dump(roc_data_storage, f)
@@ -135,7 +305,10 @@ def main():
 
     with open(LOG_FILE, "a") as f:
         f.write("\nBinary Classification Loop Completed:\n")
-        f.write(f"  Saved detailed metrics: {results_csv}\n  Saved ROC data: {roc_data_file}\n")
+        f.write(f"  Saved detailed metrics: {results_csv}\n")
+        f.write(f"  Saved extended metrics: {detailed_csv}\n")
+        f.write(f"  Saved prediction table: {pred_csv}\n")
+        f.write(f"  Saved ROC data: {roc_data_file}\n")
         f.write(f"  Saved models/selectors in: {DIRS['models_classification']}\n")
         f.write(f"  Saved selected features in: {DIRS['results_features']}\n")
 

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -18,6 +18,7 @@ def main():
         "analysis_scripts/step3_initial_clustering.py",
         "analysis_scripts/step4_prepare_binary_classification.py",
         "analysis_scripts/step5_classification_loop.py",
+        "analysis_scripts/classification3_5_metrics_plots.py",
         "analysis_scripts/step6_aggregate_visualize.py",
         "analysis_scripts/step7_validation_summary.py",
         "analysis_scripts/step8_select_best_model.py",


### PR DESCRIPTION
## Summary
- enhance step5 classification loop to record train/test metrics and save predictions
- add visualization step `classification3_5_metrics_plots.py` for average accuracy/precision/recall/F1 across TCGA train/test and CPTAC
- update pipeline to include new step

## Testing
- `python -m py_compile analysis_scripts/classification3_5_metrics_plots.py`
- `python -m py_compile analysis_scripts/step5_classification_loop.py`

------
https://chatgpt.com/codex/tasks/task_e_685166e82f7c832bb44a16bea73cb6ca